### PR TITLE
Formdata now accessible from registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vulptech/vt-form",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "type": "module",
     "license": "Apache-2.0",
     "repository": {

--- a/src/components/FormInput.vue
+++ b/src/components/FormInput.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
-import { computed, type ComputedRef, inject, watchEffect } from "vue";
+import { computed, type ComputedRef, DeepReadonly, inject, watchEffect } from "vue";
 import * as z from "zod";
 import { CircleHelp } from "lucide-vue-next";
-import { formErrorsKey, type InputSchema, type Registry, type FormError, visitedKey } from "@/types";
+import { formErrorsKey, type InputSchema, type Registry, type FormError, visitedKey, formDataKey, FormSchema } from "@/types";
 import { getZodSchema } from "@/form";
 import { Label } from "@/components/ui/label";
 import CustomTooltip from "@/components/CustomTooltip.vue";
@@ -24,6 +24,7 @@ const required = !fieldUnwrapped.isOptional();
 
 const formErrors = inject(formErrorsKey) as ComputedRef<FormError[]>;
 const isVisited = inject(visitedKey) as (key: string, value?: -1 | 0 | 1) => boolean | void;
+const formData = inject(formDataKey) as DeepReadonly<z.infer<FormSchema> | undefined>;
 
 const model = defineModel<z.infer<typeof fieldUnwrapped>>();
 
@@ -40,7 +41,7 @@ const registryItem = computed(() => {
 const computedProps = computed(() => {
     if (registryItem.value.props) {
         return Object.entries(registryItem.value.props).reduce((obj, [key, fn]) => {
-            obj[key] = fn({ def: fieldDef, meta: fieldMeta, model, field: props.field, fieldKey: props.fieldKey });
+            obj[key] = fn({ def: fieldDef, meta: fieldMeta, model: formData, field: props.field, fieldKey: props.fieldKey });
             return obj;
         }, {} as Record<string, any>);
     } else {
@@ -51,7 +52,7 @@ const computedProps = computed(() => {
 const computedEvents = computed(() => {
     if (registryItem.value.events) {
         return Object.entries(registryItem.value.events).reduce((obj, [key, fn]) => {
-            obj[key] = fn({ def: fieldDef, meta: fieldMeta, model, field: props.field, fieldKey: props.fieldKey });
+            obj[key] = fn({ def: fieldDef, meta: fieldMeta, model: formData, field: props.field, fieldKey: props.fieldKey });
             return obj;
         }, {} as Record<string, any>);
     } else {

--- a/src/composables/useVtForm.ts
+++ b/src/composables/useVtForm.ts
@@ -1,7 +1,7 @@
-import { ref, computed, provide } from "vue";
+import { ref, computed, provide, readonly } from "vue";
 import * as z from "zod";
 import { schemaCreateEmptyObject } from "@/form";
-import { type FormSchema, InputSchema, type Step, type StepConfig, formErrorsKey, visitedKey } from "@/types";
+import { type FormSchema, InputSchema, type Step, type StepConfig, formErrorsKey, visitedKey, formDataKey } from "@/types";
 
 export default function useVtForm<T extends FormSchema>(schema: T, options?: {
     steps?: StepConfig;
@@ -12,6 +12,8 @@ export default function useVtForm<T extends FormSchema>(schema: T, options?: {
     const formData = ref<z.infer<typeof schema> | undefined>();
     const isValidating = ref<boolean>(false);
     const visited = ref<Record<string, boolean>>({});
+
+    provide(formDataKey, readonly(formData));
 
     function buildVisitedObj(shape: {[key: string]: InputSchema<z.ZodTypeAny>}, keyPrefix?: string) {
         Object.entries(shape).forEach(([key, val]) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Ref, Component, HTMLAttributes, InjectionKey, ComputedRef } from "vue";
+import type { Component, HTMLAttributes, InjectionKey, ComputedRef, DeepReadonly } from "vue";
 import * as z from "zod";
 
 export const optionSchema = z.object({
@@ -228,8 +228,8 @@ export type FormSchema = z.ZodObject<{ [key: string]: InputSchema }>;
 
 export type Registry = Record<string, {
     component: Component;
-    props?: Record<string, (options: {def: z.ZodTypeDef, meta: InputMeta, model: Ref<any>, field: InputSchema, fieldKey: string}) => any>;
-    events?: Record<string, (options: {def: z.ZodTypeDef, meta: InputMeta, model: Ref<any>, field: InputSchema, fieldKey: string}) => Function>;
+    props?: Record<string, (options: {def: z.ZodTypeDef, meta: InputMeta, model: DeepReadonly<z.infer<FormSchema> | undefined>, field: InputSchema, fieldKey: string}) => any>;
+    events?: Record<string, (options: {def: z.ZodTypeDef, meta: InputMeta, model: DeepReadonly<z.infer<FormSchema> | undefined>, field: InputSchema, fieldKey: string}) => Function>;
 }>;
 
 export type Step = {
@@ -261,3 +261,5 @@ export type FormError = Omit<z.ZodIssue, "path"> & { path: string };
 export const formErrorsKey = Symbol() as InjectionKey<ComputedRef<FormError[]>>;
 
 export const visitedKey = Symbol() as InjectionKey<(key: string, value?: -1 | 0 | 1) => boolean | void>;
+
+export const formDataKey = Symbol() as InjectionKey<DeepReadonly<z.infer<FormSchema> | undefined>>;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -181,7 +181,7 @@ const schema = z.object({
         label: "custom",
         description: "description",
         type: "custom",
-        initial: "title",
+        initial: "title1",
         tooltip: "tooltip",
     }),
     divGroup: formField(z.object({
@@ -212,7 +212,7 @@ const registry: Registry = {
     custom: {
         component: MyComponent,
         props: {
-            title: ({ model }) => model.value,
+            title: ({ model }) => model.value.text === "text",
         },
     },
 };


### PR DESCRIPTION
Added a provide/inject for components in the registry to access the entire formdata state via `({ model }) => ...` rather than the component's own model. This can enable some initial conditional behaviour on other parts of the formdata state.